### PR TITLE
Some simplifications

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -607,7 +607,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		},
 		onUpdate(pokemon) {
 			const ally = pokemon.allies()[0];
-			if (this.gameType !== 'doubles' || !this.effectState.started && !pokemon.isStarted) return;
+			if (this.gameType !== 'doubles' || !this.effectState.started) return;
 			if (pokemon.switchFlag || ally?.switchFlag) return;
 			if (!ally || pokemon.baseSpecies.baseSpecies !== 'Tatsugiri' || ally.baseSpecies.baseSpecies !== 'Dondozo') {
 				// Handle any edge cases

--- a/data/items.ts
+++ b/data/items.ts
@@ -619,7 +619,7 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			((this.effect as any).onUpdate as (p: Pokemon) => void).call(this, pokemon);
 		},
 		onUpdate(pokemon) {
-			if (!this.effectState.started && !pokemon.isStarted || pokemon.transformed) return;
+			if (!this.effectState.started || pokemon.transformed) return;
 
 			if (pokemon.hasAbility('protosynthesis') && !this.field.isWeather('sunnyday') && pokemon.useItem()) {
 				pokemon.addVolatile('protosynthesis');

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -24,6 +24,7 @@ export const Scripts: ModdedBattleScriptsData = {
 	},
 	// BattlePokemon scripts.
 	pokemon: {
+		inherit: true,
 		getStat(statName, unmodified) {
 			// @ts-ignore - type checking prevents 'hp' from being passed, but we're paranoid
 			if (statName === 'hp') throw new Error("Please read `maxhp` directly");
@@ -120,6 +121,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		},
 	},
 	actions: {
+		inherit: true,
 		// This function is the main one when running a move.
 		// It deals with the beforeMove event.
 		// It also deals with how PP reduction works on gen 1.

--- a/data/mods/gen4/scripts.ts
+++ b/data/mods/gen4/scripts.ts
@@ -4,6 +4,32 @@ export const Scripts: ModdedBattleScriptsData = {
 
 	actions: {
 		inherit: true,
+		runSwitch(pokemon) {
+			this.battle.runEvent('EntryHazard', pokemon);
+
+			this.battle.runEvent('SwitchIn', pokemon);
+
+			if (this.battle.gen <= 2) {
+				// pokemon.lastMove is reset for all Pokemon on the field after a switch. This affects Mirror Move.
+				for (const poke of this.battle.getAllActive()) poke.lastMove = null;
+				if (!pokemon.side.faintedThisTurn && pokemon.draggedIn !== this.battle.turn) {
+					this.battle.runEvent('AfterSwitchInSelf', pokemon);
+				}
+			}
+			if (!pokemon.hp) return false;
+			pokemon.isStarted = true;
+			if (!pokemon.fainted) {
+				this.battle.singleEvent('Start', pokemon.getAbility(), pokemon.abilityState, pokemon);
+				this.battle.singleEvent('Start', pokemon.getItem(), pokemon.itemState, pokemon);
+			}
+			if (this.battle.gen === 4) {
+				for (const foeActive of pokemon.foes()) {
+					foeActive.removeVolatile('substitutebroken');
+				}
+			}
+			pokemon.draggedIn = null;
+			return true;
+		},
 		modifyDamage(baseDamage, pokemon, target, move, suppressMessages = false) {
 			// DPP divides modifiers into several mathematically important stages
 			// The modifiers run earlier than other generations are called with ModifyDamagePhase1 and ModifyDamagePhase2

--- a/data/mods/gen7letsgo/scripts.ts
+++ b/data/mods/gen7letsgo/scripts.ts
@@ -20,6 +20,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		}
 	},
 	actions: {
+		inherit: true,
 		canMegaEvo(pokemon) {
 			return checkMegaForme(pokemon.baseSpecies, 'Mega', this.battle);
 		},

--- a/data/mods/gen7letsgo/scripts.ts
+++ b/data/mods/gen7letsgo/scripts.ts
@@ -20,7 +20,6 @@ export const Scripts: ModdedBattleScriptsData = {
 		}
 	},
 	actions: {
-		inherit: true,
 		canMegaEvo(pokemon) {
 			return checkMegaForme(pokemon.baseSpecies, 'Mega', this.battle);
 		},

--- a/sim/battle-queue.ts
+++ b/sim/battle-queue.ts
@@ -92,7 +92,7 @@ export interface FieldAction {
 /** A generic action done by a single pokemon */
 export interface PokemonAction {
 	/** action type */
-	choice: 'megaEvo' | 'megaEvoX' | 'megaEvoY' | 'shift' | 'runPrimal' | 'runSwitch' | 'event' | 'runUnnerve' | 'runDynamax' | 'terastallize';
+	choice: 'megaEvo' | 'megaEvoX' | 'megaEvoY' | 'shift' | 'runSwitch' | 'event' | 'runDynamax' | 'terastallize';
 	/** priority of the action (lower first) */
 	priority: number;
 	/** speed of pokemon doing action (higher first if priority tie) */
@@ -174,9 +174,7 @@ export class BattleQueue {
 				beforeTurnMove: 5,
 				revivalblessing: 6,
 
-				runUnnerve: 100,
 				runSwitch: 101,
-				runPrimal: 102,
 				switch: 103,
 				megaEvo: 104,
 				megaEvoX: 104,

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -399,6 +399,7 @@ export class Battle {
 	 * 2. Priority, high to low (default 0)
 	 * 3. Speed, high to low (default 0)
 	 * 4. SubOrder, low to high (default 0)
+	 * 5. EffectOrder, low to high (default 0)
 	 *
 	 * Doesn't reference `this` so doesn't need to be bound.
 	 */

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2717,11 +2717,6 @@ export class Battle {
 		case 'runSwitch':
 			this.actions.runSwitch(action.pokemon);
 			break;
-		case 'runPrimal':
-			if (!action.pokemon.transformed) {
-				this.singleEvent('Primal', action.pokemon.getItem(), action.pokemon.itemState, action.pokemon);
-			}
-			break;
 		case 'shift':
 			if (!action.pokemon.isActive) return false;
 			if (action.pokemon.fainted) return false;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1488,6 +1488,7 @@ export class Pokemon {
 
 		this.volatileStaleness = undefined;
 
+		this.abilityState.started = false;
 		this.itemState.started = false;
 
 		this.setSpecies(this.baseSpecies);


### PR DESCRIPTION
1. Remove unused battle actions.
2. Remove redundant `isStarted`—I believe `this.effectState.started` always takes precedence over it.
3. Override `runSwitch` for gens 1-4—`inherit` was not set to `true`, so the `actions` were being overwritten entirely.